### PR TITLE
Thumb error

### DIFF
--- a/resources/UberGallery.php
+++ b/resources/UberGallery.php
@@ -464,7 +464,7 @@ class UberGallery {
         
         // If file already exists return relative path to thumbnail
         if (file_exists($destination)) {
-            $relativePath = $this->_rThumbsDir . '/' . $fileName;
+            $relativePath = $this->_rThumbsDir . '/cache/' . $fileName;
             return $relativePath;
         }
         


### PR DESCRIPTION
If you install this script as is within public_html for example or even public_html/galleryscript once you upload images into cat/dog/misc  when you load the index.php it will show error thumbnails it tries to retrieve the thumbnail from / and then displays no image, once you click on the broken image the full image still loads.
I have changed line 467 from ThumbsDir . '/' to ThumbsDir . '/cache/' and it seems to solve the issue.